### PR TITLE
When setting the test or set title dynamically the object get's printed as a JSON

### DIFF
--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -28,6 +28,7 @@ function parseProp(data: any, key: string) {
  * @example
  * interpolate('hello { username }', { username: 'virk' })
  */
+
 export function interpolate(input: string, data: any, index: number) {
   return input.replace(/(\\)?{(.*?)}/g, (_, escapeChar, key) => {
     if (escapeChar) {
@@ -40,7 +41,7 @@ export function interpolate(input: string, data: any, index: number) {
     }
 
     if (key === '$self') {
-      return data
+      return typeof data === 'string' ? data : JSON.stringify(data)
     }
 
     return parseProp(data, key)

--- a/tests/interpolate.spec.ts
+++ b/tests/interpolate.spec.ts
@@ -25,7 +25,10 @@ test.describe('Interpolate', () => {
   })
 
   test('interpolate when literval value is not a string', () => {
-    assert.equal(interpolate('hello {$self}', { foo: 'bar' }, 0), 'hello [object Object]')
+    assert.equal(
+      interpolate('hello {$self}', { foo: 'bar' }, 0),
+      `hello ${JSON.stringify({ foo: 'bar' })}`
+    )
   })
 
   test('interpolate key value is not a string', () => {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/japa/runner/issues/53

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the dataset is composed of objects with different keys, and want to print it using $self it shows the object as a a string instead of `[object Object]`.

So for a test that looks like this:

```TypeScript
 test("update a task with {$self}")
    .with([{ completed: true }, { title: "I'm happy now!" }])
    .run(async ({ assert }, changeTask) => {
      assert.equal(1 + 1, 2);
    });
```

The logging originaly looked like this:

![old_log](https://github.com/user-attachments/assets/9b0eef75-271e-4536-952a-122c91f44cec)

With the changes it will look like this:

![updated_log](https://github.com/user-attachments/assets/61e79b84-93e0-47dd-8cd6-0967fc95a970)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
