### PR TITLE
fix: avoid TypeError when timeout timer fires after test resolution (#90)

### DIFF
--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -371,7 +371,7 @@ export class TestRunner {
       debug('wrapping test in timeout timer')
       this.#timeout = {
         reject,
-        timer: setTimeout(() => this.#timeout!.reject(this.#createError('Test timeout')), duration),
+        timer: setTimeout(() => this.#timeout?.reject(this.#createError('Test timeout')), duration),
       }
     })
   }
@@ -384,7 +384,7 @@ export class TestRunner {
       debug('resetting timer')
       clearTimeout(this.#timeout.timer)
       this.#timeout.timer = setTimeout(
-        () => this.#timeout!.reject(this.#createError('Test timeout')),
+        () => this.#timeout?.reject(this.#createError('Test timeout')),
         duration
       )
     }

--- a/tests/test/execute.spec.ts
+++ b/tests/test/execute.spec.ts
@@ -337,6 +337,38 @@ test.describe('execute | async', () => {
     assert.equal(event!.errors[0].error.message, 'Test timeout')
     assert.deepEqual(stack, [])
   })
+
+  test('queued timeout callback firing after test resolution does not throw (issue #90)', async () => {
+    const emitter = new Emitter()
+    const refiner = new Refiner({})
+
+    const TIMEOUT_MS = 9_999
+    const originalSetTimeout = globalThis.setTimeout
+    const captured: Array<() => void> = []
+
+    globalThis.setTimeout = ((cb: any, ms?: number, ...args: any[]) => {
+      if (ms === TIMEOUT_MS && typeof cb === 'function') {
+        captured.push(cb as () => void)
+        return originalSetTimeout(() => {}, 0)
+      }
+      return originalSetTimeout(cb, ms as number, ...args)
+    }) as typeof setTimeout
+
+    try {
+      const testInstance = new Test('quick', new TestContext(), emitter, refiner)
+      testInstance.run(async () => {}).timeout(TIMEOUT_MS)
+
+      const [, event] = await Promise.all([testInstance.exec(), pEvent(emitter, 'test:end')])
+      assert.isFalse(event!.hasError)
+      assert.lengthOf(captured, 1)
+
+      // Simulate the race: a queued timer callback running after #clearTimer
+      // nulled #timeout. Before the fix this threw an unhandled TypeError.
+      assert.doesNotThrow(() => captured[0]())
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+    }
+  })
 })
 
 test.describe('execute | waitForDone', () => {


### PR DESCRIPTION
Fixes #90.

## Problem

Under event-loop contention, the `TestRunner` emits unhandled `TypeError: Cannot read properties of undefined (reading 'reject')` exceptions, failing CI even when every test passes.

## Root cause

`#createTimeoutTimer` and `#resetTimer` install a `setTimeout` callback that dereferences `this.#timeout!.reject` at **execution time** rather than capture time. When Node dispatches a queued timer callback after the test has already resolved and `#clearTimer()` has set `this.#timeout = undefined`, the `!.` non-null assertion is wrong and the callback throws.

\`\`\`ts
// src/test/runner.ts
timer: setTimeout(() => this.#timeout!.reject(this.#createError('Test timeout')), duration),
//                              ^^ #timeout may be undefined by the time this runs
\`\`\`

## Fix

Replace `!.` with `?.` in both call sites. The callback safely becomes a no-op once `#clearTimer` has nulled the timeout — which is the correct behavior, since the outer promise has already resolved or rejected.

\`\`\`diff
- timer: setTimeout(() => this.#timeout!.reject(this.#createError('Test timeout')), duration),
+ timer: setTimeout(() => this.#timeout?.reject(this.#createError('Test timeout')), duration),
\`\`\`

Two character changes total across `#createTimeoutTimer` and `#resetTimer`.

## Test

Added a deterministic regression test in `tests/test/execute.spec.ts`. It stubs `globalThis.setTimeout` to capture the timer callback (so the timer never fires naturally), runs a test that resolves immediately, then invokes the captured callback after `#clearTimer` has run. Before the fix this throws the exact `TypeError` from the issue; after the fix it's a no-op.

Verified locally:
- Without the fix → new test fails with `TypeError: Cannot read properties of undefined (reading 'reject')`
- With the fix → full suite green (170/170)
- Lint clean